### PR TITLE
Fix for the issue 'Updating the table data by reset with new data or add more data fails'

### DIFF
--- a/aha-table.html
+++ b/aha-table.html
@@ -437,6 +437,7 @@
 
     _dataChanged: function(changeRec) {
       if(this.data === undefined || this.data === null || (!this._isAttached && changeRec.base.length === 0)) {
+        this._internalData = [];
         return;
       }
 
@@ -592,19 +593,19 @@
           if ( Object.prototype.hasOwnProperty.call( thisObj, key ) ) {
             cellDataObj[key] = {};
             cellDataObj[key].value = thisObj[key];
-            if(resetDataState){
+            if(resetDataState || i >= this._internalData.length){
               cellDataObj[key]._validation = {passedValidation: true};
             }else{
               cellDataObj[key]._validation = this._internalData[i].row[key]._validation;
             }
           }
         }
-
+        var resetDataFlag = resetDataState || i >= this._internalData.length;
         _internalData.push({
           row: cellDataObj,
-          _filtered: (resetDataState ? false : this._internalData[i]._filtered),
-          _selected: (resetDataState ? false : this._internalData[i]._selected),
-          _highlight: (resetDataState ? {value:false, highlightColor: ''} : this._internalData[i]._highlight)
+          _filtered: (resetDataFlag ? false : this._internalData[i]._filtered),
+          _selected: (resetDataFlag ? false : this._internalData[i]._selected),
+          _highlight: (resetDataFlag ? {value:false, highlightColor: ''} : this._internalData[i]._highlight)
         });
       }
       return _internalData;

--- a/aha-table.html
+++ b/aha-table.html
@@ -588,19 +588,19 @@
           len;
       for(i = 0, len = this.data.length; i < len; i++) {
         var thisObj = this.data[i],
-            cellDataObj = {dataIndex: i };
+            cellDataObj = {dataIndex: i },
+            resetDataFlag = resetDataState || i >= this._internalData.length;
         for ( var key in thisObj ) {
           if ( Object.prototype.hasOwnProperty.call( thisObj, key ) ) {
             cellDataObj[key] = {};
             cellDataObj[key].value = thisObj[key];
-            if(resetDataState || i >= this._internalData.length){
+            if(resetDataFlag){
               cellDataObj[key]._validation = {passedValidation: true};
             }else{
               cellDataObj[key]._validation = this._internalData[i].row[key]._validation;
             }
           }
         }
-        var resetDataFlag = resetDataState || i >= this._internalData.length;
         _internalData.push({
           row: cellDataObj,
           _filtered: (resetDataFlag ? false : this._internalData[i]._filtered),
@@ -609,7 +609,6 @@
         });
       }
       return _internalData;
-
     },
 
     _initializeInternalData: function() {

--- a/test/px-data-table-fixture.html
+++ b/test/px-data-table-fixture.html
@@ -108,6 +108,18 @@
       </px-data-table>
       <hr>
 
+      <p>Reset the table with another set of data</p>
+      <px-data-table table-rows hide-pagination-control id="resetTableWithNewData">
+        <px-data-table-column name="first"></px-data-table-column>
+      </px-data-table>
+      <hr>
+
+      <p>Update the table data with adddtional set of data</p>
+      <px-data-table table-rows hide-pagination-control id="updateTableWithAdditionalData">
+        <px-data-table-column name="first"></px-data-table-column>
+      </px-data-table>
+      <hr>
+
       <p>Hide pagination controls and show all data instead of first 10.</p>
       <px-data-table hide-pagination-control id="table6"></px-data-table>
 

--- a/test/px-data-table-test.js
+++ b/test/px-data-table-test.js
@@ -1,4 +1,4 @@
-var table1Fixture, table2Fixture, table3Fixture, table4Fixture, table5Fixture, table6Fixture, dropdownFixture, filtertest;
+var table1Fixture, table2Fixture, table3Fixture, table4Fixture, table5Fixture, table6Fixture, dropdownFixture, filtertest, resetDataFixture, additionalDataFixture;
 var getStyle = function (el, style){
   return window.getComputedStyle( el, null ).getPropertyValue( style );
 };
@@ -499,6 +499,83 @@ var data =
     "color": "rgb(218,74,95)"
   }
 ];
+var additionalData = [  {
+  "index": 26,
+  "name": "Cooley Macdonald Two",
+  "first": "Aida",
+  "last": "Hurley",
+  "image": "https://s3.amazonaws.com/uifaces/faces/twitter/markwienands/73.jpg",
+  "boolean": false,
+  "guid": "466a665b-b7b6-4eae-b404-e9b5a8d1641d",
+  "integer": 20,
+  "date": "Sun Jan 05 2014 15:48:57 GMT-0800 (PST)",
+  "address": "4 Hall Street",
+  "city": "Stouchsburg",
+  "state": "District Of Columbia",
+  "zip": 32399,
+  "country": "Chile",
+  "email": "aidahurley@scentric.com",
+  "phone": "(975) 451-3272",
+  "color": "rgb(119,239,85)"
+},
+  {
+    "index": 27,
+    "name": "Snow Blankenship Two",
+    "first": "Mccormick",
+    "last": "Jensen",
+    "image": "https://s3.amazonaws.com/uifaces/faces/twitter/menghe/73.jpg",
+    "boolean": false,
+    "guid": "961f5da2-2479-4f45-9132-9e89a8bc32e4",
+    "integer": 70,
+    "date": "Tue Jan 22 1974 01:18:15 GMT-0700 (PDT)",
+    "address": "3 Lewis Place",
+    "city": "Elizaville",
+    "state": "Virgin Islands",
+    "zip": 32784,
+    "country": "Norfolk Island",
+    "email": "mccormickjensen@scentric.com",
+    "phone": "(961) 443-3343",
+    "color": "rgb(204,198,130)"
+  },
+  {
+    "index": 28,
+    "name": "Gabriela Brock Two",
+    "first": "Ramona",
+    "last": "Meyers",
+    "image": "https://s3.amazonaws.com/uifaces/faces/twitter/heyanata/73.jpg",
+    "boolean": false,
+    "guid": "07133f92-9308-420e-ae7b-e5ecd657aa85",
+    "integer": 76,
+    "date": "Sat Sep 15 1984 07:22:38 GMT-0700 (PDT)",
+    "address": "3 Rodney Street",
+    "city": "Orin",
+    "state": "Puerto Rico",
+    "zip": 60446,
+    "country": "Japan",
+    "email": "ramonameyers@scentric.com",
+    "phone": "(839) 591-3993",
+    "color": "rgb(236,222,59)"
+  },
+  {
+    "index": 29,
+    "name": "Graciela Orr Two",
+    "first": "Sharp",
+    "last": "Lindsay",
+    "image": "https://s3.amazonaws.com/uifaces/faces/twitter/thibaut_re/73.jpg",
+    "boolean": true,
+    "guid": "0ea67b0a-5ea7-4e07-8d06-48b6e2a00c6e",
+    "integer": 39,
+    "date": "Mon May 25 1970 21:04:46 GMT-0700 (PDT)",
+    "address": "2 Tech Place",
+    "city": "Kraemer",
+    "state": "Maryland",
+    "zip": 24019,
+    "country": "Saudi Arabia",
+    "email": "sharplindsay@scentric.com",
+    "phone": "(852) 538-3232",
+    "color": "rgb(218,74,95)"
+  }
+];
 var minidata =
 [
   {
@@ -696,6 +773,12 @@ document.addEventListener("WebComponentsReady", function() {
 
   filtertest = document.getElementById('filtertest');
   filtertest.tableData = minidata;
+
+  resetDataFixture = document.getElementById('resetTableWithNewData');
+  resetDataFixture.tableData = minidata;
+
+  additionalDataFixture = document.getElementById('updateTableWithAdditionalData');
+  additionalDataFixture.tableData = data;
 
   runTests();
 });
@@ -1104,7 +1187,7 @@ function runTests() {
     });
   });
 
-  suite('Column show/hide tests', function(){
+  suite('Column show/hide tests', function() {
 
       var countHidden = function(headers) {
         var hiddenNumber = 0;
@@ -1217,6 +1300,38 @@ function runTests() {
           assert.equal(Polymer.dom(chooserContent.root).querySelectorAll('li').length, noItems + 1);
           done();
         });
+    });
+  });
+
+  suite('Unit Tests for updating the data for Data Table', function () {
+
+    test('Setting table-data to different set of data removes all rows from table and sets the new data', function (done) {
+      var tb = Polymer.dom(resetDataFixture.root).querySelector('aha-table');
+      var tableData = resetDataFixture.tableData;
+      assert.equal(Polymer.dom(tb.root).querySelectorAll('.rows').length, 10);
+
+      resetDataFixture.tableData = [];
+      flush(function () {
+        assert.equal(Polymer.dom(tb.root).querySelectorAll('.rows').length, 0);
+        resetDataFixture.tableData = data;
+        flush(function () {
+          assert.equal(Polymer.dom(tb.root).querySelectorAll('.rows').length, 26);
+          done();
+        });
+      });
+
+    });
+
+    test('Adding another set of data to the table-data', function (done) {
+      var tb = Polymer.dom(additionalDataFixture.root).querySelector('aha-table');
+      var tableData = additionalDataFixture.tableData;
+      assert.equal(Polymer.dom(tb.root).querySelectorAll('.rows').length, 26);
+
+      additionalDataFixture.tableData = tableData.concat(additionalData);
+      flush(function () {
+        assert.equal(Polymer.dom(tb.root).querySelectorAll('.rows').length, 30);
+        done();
       });
     });
+  });
 }

--- a/test/px-data-table-test.js
+++ b/test/px-data-table-test.js
@@ -1187,7 +1187,7 @@ function runTests() {
     });
   });
 
-  suite('Column show/hide tests', function() {
+  suite('Column show/hide tests', function(){
 
       var countHidden = function(headers) {
         var hiddenNumber = 0;


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
This pull request would fix two issues. 
1) When the table data is reset with new set of data, reset fails. The fix is to reset the array **this._internalData** to be empty array at line no.440 in aha-table.html
2) When the table data is appended with another set of data, the update fails. The fix to have have the array _internalData added/updated with the new set of data. The changes are in the method _refreshInternalData.


* ## A reference to a related issue (if applicable): 

* ## @mentions of the person or team responsible for reviewing proposed changes:
Nagasri Grandhi - SS0 212402415

* ## working tests:
The test suite 'Unit Tests for updating the data for Data Table' has been added in px-data-table-test.js
