### PR TITLE
Expose the page size on the px-data-table.

### DIFF
--- a/aha-table.html
+++ b/aha-table.html
@@ -216,6 +216,18 @@
         value: false
       },
       /**
+       * Property to set the page size instead of the default of 10.
+       *
+       *      <px-data-table page-size="50" table-data="{{data}}"></px-data-table>
+       *
+       * @default 10
+       */
+      pageSize: {
+        type: Number,
+        value: 10,
+        observer : '_setPageSize'
+      },
+      /**
        * Property to set the visibility of the table pagination controls.
        *
        *      <px-data-table hide-pagination-control="false" table-data="{{data}}"></px-data-table>
@@ -659,6 +671,10 @@
 
     /******* Update Displayed rows when major changes ****/
 
+    _setPageSize: function() {
+      this.$.pagination.setPageSize(this.pageSize);
+    },
+    
     _updateDisplayedRows: function() {
       var fromPage,
           to;

--- a/px-data-table.html
+++ b/px-data-table.html
@@ -83,6 +83,7 @@ Events:
                  selectable="{{selectable}}"
                  selected-rows="{{selectedRows}}"
                  meta="{{meta}}"
+                 page-size="{{pageSize}}"
                  hide-pagination-control="{{hidePaginationControl}}"
                  show-column-chooser="{{showColumnChooser}}"
                  enable-column-reorder="{{enableColumnReorder}}"
@@ -205,6 +206,18 @@ Events:
       hidePaginationControl: {
         type: Boolean,
         value: false
+      },
+
+      /**
+       * Property to set the page size instead of the default of 10.
+       *
+       *      <px-data-table page-size="50" table-data="{{data}}"></px-data-table>
+       *
+       * @default 10
+       */
+      pageSize: {
+        type: Number,
+        value: 10
       },
 
       /**

--- a/px-pagination.html
+++ b/px-pagination.html
@@ -135,17 +135,30 @@ Element that provides pagination.
       }
     },
 
+    /**
+     * Set page size public interface.
+     * 
+     * Set Page size, trigger update of table, update combobox.
+     */
+    setPageSize: function(size) {
+      this._updatePageSize(size);
+    },
+
     _changeDropDown: function(e) {
+      this._updatePageSize(parseInt(e.target.value));
+    },
+
+    _updatePageSize: function(size) {
       var sizelist = [10, 20, 50, 100];
-      var size = parseInt(e.target.value),
-        index = sizelist.indexOf(size);
+      var index = sizelist.indexOf(size);
+
       var parentElem = this.$.pageSizeSelect,
         optionList = Polymer.dom(parentElem).querySelectorAll("option");
 
       optionList.forEach(function(option) {
         if(parseInt(option.value) === parseInt(size)) {
           option.setAttribute('selected', '');
-          e.target.selectedIndex = parseInt(index);
+          parentElem.selectedIndex = parseInt(index);
         } else {
           option.removeAttribute('selected');
         }


### PR DESCRIPTION
Hi,

In this modification, I am exposing the pagesize on the px-data-table.
In my application I do not want to start with a table with 10 elements but more.
I think this change will be helpful to all.

This code is tested and included in the GE Plant Optimizer app.

Best regards,
Flo
