### PR TITLE
Fix for Turbo Asset UI: Tooltip pops up and does not hide anymore

### DIFF
--- a/px-data-table-cell.html
+++ b/px-data-table-cell.html
@@ -55,7 +55,7 @@
               <px-tooltip
                 orientation="top"
                 smart-orientation
-                delay="1000"
+                delay="100"
                 tooltip-message="{{cellValue}}">
               </px-tooltip>
             </template>


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
The change proposed is at the line 58 changed the delay '1000' to '100'
 <px-tooltip
                orientation="top"
                smart-orientation
                **delay="100"**
                tooltip-message="{{cellValue}}">
              </px-tooltip>

* ## A reference to a related issue (if applicable):
We have a data table and column cell is clickable and has restricted length which will enable the tooptip. When the cell is clicked before 1 sec (1000 sec delay imposed on the tootltip to display), the tooltip is not hidden even the control goes to next page.
![screen shot 2016-08-18 at 11 56 41 am](https://cloud.githubusercontent.com/assets/19353085/18596463/18ac5ede-7bfe-11e6-8dd5-3277ecf617d2.png)


* ## @mentions of the person or team responsible for reviewing proposed changes:
Team Turbo Asset

* ## working tests:
Since it is simple configuration change, no tests were effected/written.
