### PR TITLE
fix: re-generate `selectedRows` when data are changed

### DIFF
--- a/aha-table.html
+++ b/aha-table.html
@@ -476,6 +476,10 @@
       } else{
         this._internalData = this._refreshInternalData();
       }
+      this.selectedRows = this._internalData.filter(function(it){
+        return it._selected === true;
+      });
+
       this._filterSortAndUpdateDisplayedTable();
 
       var pathNumber = new RegExp('([#])([0-9])+');
@@ -674,7 +678,7 @@
     _setPageSize: function() {
       this.$.pagination.setPageSize(this.pageSize);
     },
-    
+
     _updateDisplayedRows: function() {
       var fromPage,
           to;

--- a/test/px-data-table-fixture.html
+++ b/test/px-data-table-fixture.html
@@ -135,5 +135,8 @@
         app.meta = [{name: 'first'}, {name: 'last'}, {name: 'email'}];
       </script>
 
+      <p>Selection after data update does not contain unreached data</p>
+      <px-data-table id="updateTableWithSelection" selectable></px-data-table>
+
   </body>
 </html>

--- a/test/px-data-table-test.js
+++ b/test/px-data-table-test.js
@@ -1,4 +1,4 @@
-var table1Fixture, table2Fixture, table3Fixture, table4Fixture, table5Fixture, table6Fixture, dropdownFixture, filtertest, resetDataFixture, additionalDataFixture;
+var table1Fixture, table2Fixture, table3Fixture, table4Fixture, table5Fixture, table6Fixture, dropdownFixture, filtertest, resetDataFixture, additionalDataFixture, updateSelectFixture;
 var getStyle = function (el, style){
   return window.getComputedStyle( el, null ).getPropertyValue( style );
 };
@@ -780,6 +780,10 @@ document.addEventListener("WebComponentsReady", function() {
   additionalDataFixture = document.getElementById('updateTableWithAdditionalData');
   additionalDataFixture.tableData = data;
 
+  updateSelectFixture = document.getElementById('updateTableWithSelection');
+  // use `data.slice()` to avoid breaking `additionalDataFixture` tests
+  updateSelectFixture.tableData = data.slice();
+
   runTests();
 });
 
@@ -1129,6 +1133,32 @@ function runTests() {
         });
       });
 
+    });
+
+    test('Modifying data with selected rows updates `selectedRows`', function(done){
+      var tableData = updateSelectFixture.tableData;
+      assert.equal(updateSelectFixture.selectedRows.length, 0);
+
+      // select the checkbox on the first row (the first one is global selector!)
+      var firstRowCheckbox = updateSelectFixture.querySelectorAll("input[type=checkbox]")[1];
+
+      // click on the checkbox to select the row
+      firstRowCheckbox.click();
+      flush(function(){
+        assert.equal(updateSelectFixture.selectedRows.length, 1);
+
+        // update table data. every operation will work.
+        updateSelectFixture.push("tableData", tableData[0]);
+        flush(function(){
+          // de-select the row
+          firstRowCheckbox.click();
+
+          flush(function() {
+            assert.equal(updateSelectFixture.selectedRows.length, 0);
+            done();
+          });
+        });
+      });
     });
 
   });


### PR DESCRIPTION
This PR aims to fix #62 by re-generating the `selectedRows` array when data are changed.

As explained in the related issue, `selectedRows` contains references to objects that are not available inside `_internalData` when the `dataChanged(data.*)` observer is called. The missed update breaks the logic inside `_selectRow`, leading it to add items that the user considers "not selected" to `selectedRows`.

Fixes #62 