### PR TITLE
Added expanded property to show inline div on row click event which can be used as a container to display any other component

### DIFF
--- a/aha-table.html
+++ b/aha-table.html
@@ -78,7 +78,7 @@
         <!-- Data rows -->
         <template id="recordList" is="dom-repeat" items="{{displayedRows}}" as="internalRow" strip-whitespace>
 
-          <div class$="{{_getRowClass(internalRow,striped)}}">
+          <div class$="{{_getRowClass(internalRow,striped)}}" on-tap="_rowTap" data-args="[[internalRow]]">
             <!-- Data cells -->
             <template is="dom-repeat" items="{{meta}}" as="column">
               <template is="dom-if" if="{{_isFalse(column.hide)}}">
@@ -113,6 +113,9 @@
                 </template>
               </template>
             </template>
+          </div>
+		  <div id="px-row-detail" is="dom-if" if="{{expandable}}">
+                        
           </div>
         </template>
       </div>
@@ -165,6 +168,11 @@
         type: Boolean,
         value: false,
         observer: "_selectableChanged"
+      },
+      //expandable: if table row is expandable
+      expandable: {
+        type: Boolean,
+        value: false,
       },
       //striped: if table row is striped
       striped: {
@@ -1381,6 +1389,32 @@
       }
     },
     /******** Display table helpers (classes, dom-if functions, etc.) *************/
+    _rowTap: function (e) {
+      this.fire('row-tap', {
+        'e': e,
+        'row': e.currentTarget.dataArgs,
+        'data': this.data[e.currentTarget.dataArgs.row.dataIndex]
+      });
+      if (this.expandable) {
+        if (e.currentTarget.dataArgs.expanded) {
+          e.currentTarget.setAttribute('expanded', false);
+          e.currentTarget.dataArgs.expanded = false;
+          this.fire('row-collapse', {
+            'e': e,
+            'row': e.currentTarget.dataArgs,
+            'data': this.data[e.currentTarget.dataArgs.row.dataIndex]
+          })
+        } else {
+          e.currentTarget.setAttribute('expanded', true);
+          e.currentTarget.dataArgs.expanded = true;
+          this.fire('row-expand', {
+            'e': e,
+            'row': e.currentTarget.dataArgs,
+            'data': this.data[e.currentTarget.dataArgs.row.dataIndex]
+          });
+        }
+      }
+    },
 
     _getRowClass: function(row,striped) {
       return ['tr', 'rows',

--- a/aha-table.html
+++ b/aha-table.html
@@ -114,9 +114,9 @@
               </template>
             </template>
           </div>
-		  <template id="px-row-detail" is="dom-if" if="{{expandable}}">
-            <div class="flex flex--center" is="dom-if"></div>
-          </template>
+            <template id="px-row-detail" is="dom-if" if="{{expandable}}">
+                <div class="flex flex--center" if="{{expandable}}"> Inner content goes here</div>
+            </template>
         </template>
       </div>
 

--- a/aha-table.html
+++ b/aha-table.html
@@ -115,7 +115,7 @@
             </template>
           </div>
 		  <template id="px-row-detail" is="dom-if" if="{{expandable}}">
-            <div class="flex flex--center" is="dom-if" if="{{expandable}}">Row details Content goes here</div>
+            <div class="flex flex--center" is="dom-if"></div>
           </template>
         </template>
       </div>

--- a/aha-table.html
+++ b/aha-table.html
@@ -114,9 +114,9 @@
               </template>
             </template>
           </div>
-		  <div id="px-row-detail" is="dom-if" if="{{expandable}}">
-                        
-          </div>
+		  <template id="px-row-detail" is="dom-if" if="{{expandable}}">
+            <div class="flex flex--center" is="dom-if" if="{{expandable}}">Row details Content goes here</div>
+          </template>
         </template>
       </div>
 

--- a/demo.html
+++ b/demo.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 
 <html>
   <head>
@@ -42,6 +42,11 @@
       <px-data-table table-rows enable-column-reorder table-data="{{data}}"></px-data-table>
 
       <hr>
+
+        <p>Expanding Row functionality to show inline content on row click.</p>
+        <px-data-table id="mytableForRowExpand" table-rows table-data="{{data}}" expandable></px-data-table>
+
+        <hr>
 
       <h3>Very customized data table</h3>
 
@@ -169,6 +174,25 @@
             var clickedRow = e.detail.row;
             console.log("Row clicked", clickedRow, " _selected: ", clickedRow._selected);
           });
+
+          var allRows = document.querySelectorAll('#mytableForRowExpand div.rows');
+
+          for (var i = 0; i < allRows.length; i++) {
+              allRows[i].addEventListener('click', function (e, data) {
+                  if (e.currentTarget.dataArgs.expanded) {
+                      var container = e.currentTarget.nextElementSibling;
+                      var newDivElement = document.createElement("div");
+                      newDivElement.innerHTML = "The Inner text or Control can be placed here";
+                      container.append(newDivElement);
+                  }
+                  else {
+                      var parent = e.currentTarget.nextElementSibling;
+                      while (parent.hasChildNodes()) {
+                          parent.removeChild(parent.lastChild);
+                      }
+                  }
+              });
+          }
         });
 
 

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
                 <div class="u-ml-">Hide Pagination Control</div>
               </div>
               <div class="flex u-mb-">
-                  <input id="rowExpand{{indexPlusOne(index)}}" class="toggle__input toggle__input--small" type="checkbox" checked="{{item.expandable::change}}">
+                  <input id="rowExpand{{indexPlusOne(index)}}" class="toggle__input toggle__input--small" type="checkbox" checked="{{item.expandable::change}}"  onclick="addRowExpandEventListeners()">
                   <label for$="rowExpand{{indexPlusOne(index)}}" class="toggle__label toggle__label--small"></label>
                   <div class="u-ml-">Row Expand</div>
               </div>
@@ -118,7 +118,7 @@
                 <div class="flex flex--col">
                   <div class="demo u-p+">
 
-                  <px-data-table
+                  <px-data-table id="demoPxDataTable"
                   table-data="{{item.tableData}}"
                   striped="{{item.striped}}"
                   filterable="{{item.filterable}}"
@@ -264,6 +264,28 @@ window.addEventListener('WebComponentsReady', function() {
     template.optionsArray = optionsArray;
     template.indexPlusOne = indexPlusOne;
 });
+function addRowExpandEventListeners() {
+    /*Adding event listener to all rows to expand on click and show a div inside it */
+    var allRows = document.querySelectorAll('#demoPxDataTable div.rows');
+
+    for (var i = 0; i < allRows.length; i++) {
+        allRows[i].addEventListener('click', function (e, data) {
+            if (e.currentTarget.dataArgs.expanded) {
+                var container = e.currentTarget.nextElementSibling;
+                var newDivElement = document.createElement("div");
+                newDivElement.innerHTML = "The Inner text or Control can be placed here";
+                container.append(newDivElement);
+            }
+            else {
+                var parent = e.currentTarget.nextElementSibling;
+                while (parent.hasChildNodes()) {
+                    parent.removeChild(parent.lastChild);
+                }
+            }
+        });
+    }
+
+}
 </script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html>
 <head>
   <meta charset="utf-8">
@@ -95,6 +95,11 @@
                 <label for$="hidePaginationControl{{indexPlusOne(index)}}" class="toggle__label toggle__label--small"></label>
                 <div class="u-ml-">Hide Pagination Control</div>
               </div>
+              <div class="flex u-mb-">
+                  <input id="rowExpand{{indexPlusOne(index)}}" class="toggle__input toggle__input--small" type="checkbox" checked="{{item.expandable::change}}">
+                  <label for$="rowExpand{{indexPlusOne(index)}}" class="toggle__label toggle__label--small"></label>
+                  <div class="u-ml-">Row Expand</div>
+              </div>
               <p class="zeta">
                 Note: the following properties are not dynamically reflected at this time, but you can view the differences by using the "Option" tabs above.
               </p>
@@ -123,6 +128,7 @@
                   enable-column-resize="{{item.enableColumnResize}}"
                   table-columns="{{item.tableColumns}}"
                   table-rows="{{item.tableRows}}"
+                  expandable="{{item.expandable}}"
                   hide-pagination-control="{{item.hidePaginationControl}}">
                     <px-data-table-column name="first" filterable></px-data-table-column>
                     <px-data-table-column name="last" filterable></px-data-table-column>

--- a/px-data-table.html
+++ b/px-data-table.html
@@ -88,7 +88,8 @@ Events:
                  show-column-chooser="{{showColumnChooser}}"
                  enable-column-reorder="{{enableColumnReorder}}"
                  enable-column-resize="{{enableColumnResize}}"
-                 id="dataTable">
+                 id="dataTable"
+				 expandable="{{expandable}}">
                  <content></content>
       </aha-table>
     </div>
@@ -156,6 +157,19 @@ Events:
        * @default false
        */
       filterable: {
+        type: Boolean,
+        value: false
+      },
+
+      /**
+       * Use the expandable attribute if the table has expandable functionality per row turned on.
+       *    <px-data-table expandable table-data="{{data}}"></px-data-table>
+       * If columns are specified with px-data-table-column, they must have a expandable attribute to be able to be expanded.
+       * Need to implement px-row-expand and px-row-collapse listeners and add/remove content using them.
+       * Add content to #rowDetail
+       * @default false
+       */
+      expandable: {
         type: Boolean,
         value: false
       },
@@ -269,7 +283,17 @@ Events:
         value: false
       }
     },
-
+	/**
+     * Listeners:
+     *
+     * This will listen to the events
+     *
+     */
+    listeners: {
+      'row-tap': 'onRowTap',
+      'row-expand': 'onRowExpand',
+      'row-collapse': 'onRowCollapse',
+    },
     /**
      * Events:
      *
@@ -277,5 +301,17 @@ Events:
      *
      */
 
+    onRowTap(e, data) {
+      this.fire('px-row-tap', data);
+    },
+
+    onRowExpand(e, data) {
+      this.fire('px-row-expand', data);
+    },
+
+    onRowCollapse(e, data) {
+      this.fire('px-row-collapse', data);
+    },
   });
+
 </script>

--- a/test/px-data-table-fixture.html
+++ b/test/px-data-table-fixture.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 
 <html>
   <head>
@@ -137,6 +137,9 @@
 
       <p>Selection after data update does not contain unreached data</p>
       <px-data-table id="updateTableWithSelection" selectable></px-data-table>
+
+      <p>Row click to show inline div/container in which we can place another comonent.</p>
+      <px-data-table id="dataTableWithRowClick" expandable></px-data-table>
 
   </body>
 </html>

--- a/test/px-data-table-test.js
+++ b/test/px-data-table-test.js
@@ -784,6 +784,9 @@ document.addEventListener("WebComponentsReady", function() {
   // use `data.slice()` to avoid breaking `additionalDataFixture` tests
   updateSelectFixture.tableData = data.slice();
 
+  dataTableWithRowClickFixture = document.getElementById('dataTableWithRowClick');
+  dataTableWithRowClickFixture.tableData = data;
+
   runTests();
 });
 
@@ -811,16 +814,17 @@ function runTests() {
     test('myTable fixture is created', function() {
       assert.isTrue(document.getElementById('myTable') !== null);
     });
-
+    test('dataTableWithRowClick fixture is created', function () {
+        assert.isTrue(document.getElementById('dataTableWithRowClick') !== null);
+    });
     // Spot checks for correct table structure, cell values and control states
 
     test('There should be 17 columns in the table1 fixture', function() {
-
       // Select a div corresponding to a data row in the table
-      var divSelector = '#dataTable > .scroll-body.style-scope.aha-table > div > :nth-child(4)';
+var divSelector = '#dataTable > .scroll-body.style-scope.aha-table > div > :nth-child(5)';
       var divRow = document.querySelector(divSelector);
       // Select all <span> children of divRow
-      var childSpanSelector = ':nth-child(4) > .td.style-scope.aha-table';
+      var childSpanSelector = ':nth-child(5) > .td.style-scope.aha-table';
       var columnCount = divRow.querySelectorAll(childSpanSelector).length;
       // There should be 17 such spans
       assert.equal(columnCount, 17);
@@ -881,7 +885,7 @@ function runTests() {
       var lastNameFilter = filterableTableRoot.querySelector(lastNameFilterSelector);
       lastNameFilter.addEventListener('keyup', function(e){
         setTimeout(function() {
-          var secondReturnedRowFirstNameSelector = '#dataTable :nth-child(4) .aha-first-td';
+          var secondReturnedRowFirstNameSelector = '#dataTable :nth-child(5) .aha-first-td';
           var secondReturnedRowFirstName = filterableTableRoot.querySelector(secondReturnedRowFirstNameSelector);
           assert.equal(secondReturnedRowFirstName.innerHTML.indexOf('Rita') >= 0, true);
           done(); // end the test
@@ -1389,5 +1393,32 @@ function runTests() {
         done();
       });
     });
+  });
+
+  suite('Unit Tests to check row click event based on expanded property', function () {
+
+      // Spot checks for row click functionality
+      test('Row click is perfomed correctly when row is clicked', function (done) {
+          
+          var clickableTableRoot = document.querySelector('#dataTableWithRowClick');
+          var dataRowSelector = '.rows';
+          var dataRow = clickableTableRoot.querySelector(dataRowSelector);
+          dataRow.addEventListener('click', function (e) {
+              setTimeout(function () {
+                  var rowDetailsContainer = clickableTableRoot.querySelector(".rows + div");
+                  rowDetailsContainer.textContent = "Row is clicked";
+                  var updatedRowDetailsContainerText = Polymer.dom(dataTableWithRowClickFixture.root).querySelector('aha-table').querySelector(".rows + div");
+
+                  //make sure row click had updated the inner container textContent
+                  assert.equal(updatedRowDetailsContainerText.textContent, 'Row is clicked');
+                  
+                  done();
+
+              }, 0);
+          });
+          // Trigger a click on the First Name column header
+          dataRow.click();
+         
+      });
   });
 }


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
We have a requirement to show inline px-data-table on row click of parent px-data-table. So i have added a div container to that can container web component. It will be hidden or displayed on row click event. And this row click event is enabled/disabled by an expanded property.

* ## A reference to a related issue (if applicable):
This is a generic requirement as well as we need this in our project.


* ## @mentions of the person or team responsible for reviewing proposed changes:
Please review my changes so that it can be merged into master.

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
…an be used as a container to display any other component

Added expanded property to show inline div on row click event which can
be used as a container to display any other component