### PR TITLE
bug fix: 86. Select all will only select displayed rows

### DIFF
--- a/aha-table.html
+++ b/aha-table.html
@@ -638,9 +638,8 @@
 
       //update selected rows when changing the filter if the select all is enabled
       selectAllCheckbox = Polymer.dom(this.root).querySelector("#selectAllCheckbox");
-      if(selectAllCheckbox !== null && selectAllCheckbox !== undefined){
-        if(selectAllCheckbox.checked)
-          this._setAllRows(true);
+      if(selectAllCheckbox !== null && selectAllCheckbox !== undefined && selectAllCheckbox.checked){
+          selectAllCheckbox.checked=false;
       }
     },
 

--- a/aha-table.html
+++ b/aha-table.html
@@ -635,6 +635,13 @@
       // with filtering/sorting, it's best just to go back to the first page
       this.$.pagination.goToPageNumber(1);
       this._updateDisplayedRows();
+
+      //update selected rows when changing the filter if the select all is enabled
+      selectAllCheckbox = Polymer.dom(this.root).querySelector("#selectAllCheckbox");
+      if(selectAllCheckbox !== null && selectAllCheckbox !== undefined){
+        if(selectAllCheckbox.checked)
+          this._setAllRows(true);
+      }
     },
 
     /********** Internal data structure ***********/
@@ -1019,9 +1026,19 @@
     _setAllRows: function(isSelected) {
       var i,
           len;
-      // set all rows selected/unselected
-      for(i = 0, len = this._internalData.length; i < len; i++) {
-        this._setInternalDataAt(this._internalData[i], '_selected', isSelected);
+
+      if(isSelected) {
+      //set selected to true when selecing all for tags shown by filter
+        for(i = 0, len = this._internalData.length; i < len; i++) {
+          if(this.filteredSortedData.includes(this._internalData[i])){
+            this._setInternalDataAt(this._internalData[i], '_selected', isSelected);
+          }
+        }
+      } else {
+        //set selected to false
+        for(i = 0, len = this._internalData.length; i < len; i++) {
+          this._setInternalDataAt(this._internalData[i], '_selected', isSelected);
+        }
       }
 
       // notify viewing rows of change
@@ -1034,7 +1051,9 @@
       if(isSelected) {
         // add everything to selectedRows property
         for(i = 0, len = this._internalData.length; i < len; i++) {
-          this.push('selectedRows', this._internalData[i]);
+          if(this._internalData[i]._selected) {
+            this.push('selectedRows', this._internalData[i]);
+          }
         }
       }
 

--- a/test/px-data-table-test.js
+++ b/test/px-data-table-test.js
@@ -886,6 +886,29 @@ function runTests() {
       lastNameFilter.dispatchEvent(new Event('keyup'));
     });
 
+    test('When selecting all, select only what is filtered', function(done){
+
+      var tb = Polymer.dom(table2Fixture.root).querySelector('aha-table');
+      table2Fixture.tableData = table1Fixture.tableData;
+
+      var filterableTableRoot = document.querySelector('#table2');
+      var lastNameFilterSelector = 'div > div.tr.tr--filter > :nth-child(2) > input';
+      var lastNameFilter = filterableTableRoot.querySelector(lastNameFilterSelector);
+
+      // Trigger filter edit event and provide a filter value
+      lastNameFilter.value = 'a';
+      lastNameFilter.dispatchEvent(new Event('keyup'));
+
+      var secondReturnedRowFirstNameSelector = '#dataTable :nth-child(4) .aha-first-td';
+      var secondReturnedRowFirstName = filterableTableRoot.querySelector(secondReturnedRowFirstNameSelector);
+
+      var selectionPath = '#dataTable';
+      filterableTableRoot.querySelector("#selectAllCheckbox").checked = true;
+
+      assert.equal(table2Fixture.selectedRows.length < table2Fixture.tableData.length, true, 'selceted row is not less that all rows');
+      done();
+    });
+
     // Spot checks for sorting functionality
     test('Records are sorted correctly when a sortable column header is clicked', function(done) {
       var sortableTableRoot = document.querySelector('#table1');
@@ -1217,7 +1240,7 @@ function runTests() {
       var filterRowEl = Polymer.dom(filterInnerTable.root).querySelector('.tr--filter');
       var selectionPath = '#dataTable :nth-child(3) .td input[type=radio]';
 
-      filtertest.filterable = false;
+      filtertest.filterable = true;
       filtertest.selectable = true;
       filtertest.singleSelect = true;
       flush(function() {
@@ -1227,7 +1250,7 @@ function runTests() {
         done();
       });
     });
-  });
+});
 
   suite('Column show/hide tests', function(){
 

--- a/test/px-data-table-test.js
+++ b/test/px-data-table-test.js
@@ -889,15 +889,10 @@ function runTests() {
     test('When selecting all, select only what is filtered', function(done){
 
       var tb = Polymer.dom(table2Fixture.root).querySelector('aha-table');
-      table2Fixture.tableData = table1Fixture.tableData;
 
       var filterableTableRoot = document.querySelector('#table2');
       var lastNameFilterSelector = 'div > div.tr.tr--filter > :nth-child(2) > input';
       var lastNameFilter = filterableTableRoot.querySelector(lastNameFilterSelector);
-
-      // Trigger filter edit event and provide a filter value
-      lastNameFilter.value = 'a';
-      lastNameFilter.dispatchEvent(new Event('keyup'));
 
       var secondReturnedRowFirstNameSelector = '#dataTable :nth-child(4) .aha-first-td';
       var secondReturnedRowFirstName = filterableTableRoot.querySelector(secondReturnedRowFirstNameSelector);
@@ -1240,7 +1235,7 @@ function runTests() {
       var filterRowEl = Polymer.dom(filterInnerTable.root).querySelector('.tr--filter');
       var selectionPath = '#dataTable :nth-child(3) .td input[type=radio]';
 
-      filtertest.filterable = true;
+      filtertest.filterable = false;
       filtertest.selectable = true;
       filtertest.singleSelect = true;
       flush(function() {


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
- Bug fix: Selected the select 'select all' button will only select the rows displayed
* ## A reference to a related issue (if applicable):
https://github.com/PredixDev/px-data-table/issues/86
* ## @mentions of the person or team responsible for reviewing proposed changes:
@randyaskin 
* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
test/px-data-table-test.js -'When selecting all, select only what is filtered'
