### PR TITLE
add data parameters to highlight method call (fixed)

### DIFF
--- a/aha-table.html
+++ b/aha-table.html
@@ -727,6 +727,15 @@
       }
     },
 
+    _getInternalRowStateAt: function (row, columnName) {
+      if(columnName === '_selected' || columnName === '_filtered') {
+        return row;
+      }
+      else {
+        return row.row;
+      }
+    },
+
     /******* Update Displayed rows when major changes ****/
 
     _updateDisplayedRows: function() {
@@ -1438,7 +1447,9 @@
           highlightClass;
 
       highlightElements.forEach(function(highlightEl) {
-        doHighlight = highlightEl.highlight(this._getInternalDataAt(row, column.name));
+        var rowState = this._getInternalRowStateAt(row, column.name);
+        var data = this._getInternalDataAt(row, column.name);
+        doHighlight = highlightEl.highlight(data, rowState, column.name);
         if (highlightObj.value && doHighlight) {
           if(highlightObj.highlightValue === 'low'){
             highlightObj.highlightClass = 'px-data-table-highlight--' + highlightEl.highlightValue;

--- a/px-data-table-highlight.html
+++ b/px-data-table-highlight.html
@@ -60,6 +60,7 @@ Custom property | Description | Default
       },
       /**
        * A JavaScript method name from the file located at the `import` url.
+       * Highlight method receives three parameters: cell value, row data, column name.
        */
       highlightMethod: {
         type: String,


### PR DESCRIPTION
# Pull Request

* ## A description of the changes proposed in the pull request:

Highlight methods now receives row data and column name parameters.
It is easier to write highlight methods that depends other cells of same row.

* ## A reference to a related issue (if applicable):

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
