### PR TITLE
Fixing Selecting and Filtering + Documentation Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,32 @@ Minimum - Client-Side Sort/Filter/Pagination:
 Minimum - Server-Side Sort/Filter/Pagination:
 
     <px-data-table
-      table-data="{{data}}"
+      total-entries="100"
+      first-item-index="11"
+      table-data="{{dataSubset}}"
       remote-data="true"
       >
     </px-data-table>
 
 ```
+
+### Client-Side VS Server-Side Data Paradigms
+
+There are two main paradigms for the source of data in a table.
+
+In a *Client-Side* model, the browser makes one request for the _complete set_ of data.
+This means that sorting, filtering, and pagination all happen in memory on the client.
+While this produces snappy tables with reasonably sized data sets, it can lead to a sluggish UI
+for larger data sets. This works great with data sets that don't change frequently,
+since the full payload would have to be resent for every update.
+
+In a *Server-Side* model, the browser makes a request for a _subset_ of data for a particular page.
+Sorting, filtering, and pagination requests will have to be made to a service for a new _subset_ of data
+that matches the user's intended criteria. This prevents the browser from being overwhelmed with excessively
+large data sets by only exposing one page's worth of data at a time. This is ideal for larger data sets or
+where it is preferable to make multiple small requests instead of fewer larger requests. Due to the increased
+frequency of requests, the UI is more likely to display data in sync with the server.
+
 
 ### Client Side Sort/Filter/Pagination
 

--- a/aha-table.html
+++ b/aha-table.html
@@ -31,7 +31,7 @@
 
     <div class="scroll-body">
 
-      <div id="scrollBodyTableContainer" class$="{{_getTableClass(tableCells, tableColumns)}}" role="grid">
+      <div id="scrollBodyTableContainer" class$="table {{_getTableClass(tableCells, tableColumns)}}" role="grid">
         <!-- Header -->
         <div class="tr" role="row">
           <template is="dom-repeat" items="{{meta}}" as="column">
@@ -1750,14 +1750,14 @@
       return classList.join(' ');
     },
     _getTableClass: function(tableCells, tableColumns) {
-      var classList = ['table'];
+      var classArray = [];
       if(tableCells) {
-        classList.push('table--cells');
+        classArray.push('table--cells');
       }
       if (tableColumns) {
-        classList.push('table--columns');
+        classArray.push('table--columns');
       }
-      return classList.join(' ');
+      return classArray.join(' ');
     },
     _getPaginationVisibility: function (hidePaginationControl) {
       return (hidePaginationControl ? "visuallyhidden" : "");

--- a/aha-table.html
+++ b/aha-table.html
@@ -61,41 +61,14 @@
               <template is="dom-if" if="{{_isEqual(column.type, 'selected')}}">
                 <span class="flex" hidden$="{{column.hide}}">
                   <template is="dom-if" if="{{!singleSelect}}">
-                    <input role="checkbox" id="selectAllCheckbox" aria-label="Click to select row" type="checkbox" checked="{{internalRow._selected::change}}"/>
-                  </template>
-                  <template is="dom-if" if="{{singleSelect}}">
-                    <input role="checkbox" id="selectAllCheckbox" aria-label="Click to select row" type="radio" name="selected" checked="{{internalRow._selected::change}}"/>
+                    <input id="selectAllCheckbox" role="checkbox" aria-label="Click to select or deselect all rows" type="checkbox" on-change="_clickSelectAll"/>
                   </template>
                 </span>
               </template>
-              <template id="cellRepeat" is="dom-if" if="{{!_isEqual(column.type, 'selected')}}">
-                <template is="dom-if" if="{{!column.hide}}">
-                  <px-data-table-cell
-                    cell-display-tooltip="{{_shouldClipDatumString(internalRow, column)}}"
-                    cell-display-value="{{_readContent(internalRow, column)}}"
-                    cell-editable="{{column.editable}}"
-                    cell-highlighted="[[_getHighlightValue(internalRow, column, column.highlightdefined)]]"
-                    cell-selected="[[internalRow._selected]]"
-                    cell-type="{{column.type}}"
-                    cell-validation="{{_getInternalCellValidationStateAt(internalRow, column.name)}}"
-                    cell-value="{{_getInternalDataAt(internalRow, column.name)}}"
-                    column-name="{{column.name}}"
-                    dropdown-bounds="{{scrollBody}}"
-                    dropdown-items="{{column.dropdownItems}}"
-                    dropdown-max-character-width="{{column.maxColumnCharacterWidth}}"
-                    on-save="_save"
-                    on-tap="_clickCell"
-                    on-validate="_handleValidateEvent"
-                    placeholder="{{column.placeholder}}"
-                    row-highlighted="[[internalRow._highlight]]"
-                    >
-                  </px-data-table-cell>
-                </template>
 
-                <!-- filter entry -->
-                <template is="dom-if" if="{{_isFilterableColumn(column, filterable)}}">
-                  <input role="textbox" aria-label="Enter text to filter column" placeholder="{{localize('Filter')}}" class="text-input text-input--filter" type="text" on-input="_filter" />
-                </template>
+              <!-- filter entry -->
+              <template is="dom-if" if="{{_isFilterableColumn(column, filterable)}}">
+                <input role="textbox" aria-label="Enter text to filter column" placeholder="{{localize('Filter')}}" class="text-input text-input--filter" type="text" on-input="_filter" />
               </template>
             </span>
           </template>
@@ -334,11 +307,21 @@
         value: 10,
         observer: '_setPageSize'
       },
-      // when dataRemote is true, then this reflects the total count on observer
-      // and numberOfItems reflects count of items in table
+
+      /**
+       * When dataRemote is true, then this reflects the total count on observer
+       * and numberOfItems reflects count of items in tableProperty to track the number of items in the table
+       */
       _adaptedNumberOfItems: {
         type: Number,
       },
+
+      /**
+       * Property to track the number of items in the table
+       *
+       * Without dataRemote==true, this will be the total number of items
+       * With dataRemote==true this will either be the page size or the number of items if less than the page size
+       */
       numberOfItems: {
         type: Number,
         observer: '_calculateAdaptedNumberOfItems'

--- a/demo/px-data-table-demo.html
+++ b/demo/px-data-table-demo.html
@@ -19,6 +19,43 @@
 <dom-module id="px-data-table-demo">
   <template>
     <style include="px-demo-styles" is="custom-style"></style>
+    <style>
+      #toaster {
+        position: fixed;
+        top: 0;
+        right: 0;
+        margin-left: 7px;
+        width: 70%;
+        border: 1px solid #c5d1d8;
+        background: #fff;
+        padding: 2em;
+        margin-right: 1em;
+        margin-top: 7px;
+        max-width: 45em;
+        z-index: 1;
+      }
+      .toaster--action-container {
+        text-align: right;
+        margin-top: 1em;
+      }
+      .toaster--title {
+        font-weight: bold;
+      }
+      .toaster--detail {
+        white-space: pre-wrap;       /* Since CSS 2.1 */
+        white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+        white-space: -pre-wrap;      /* Opera 4-6 */
+        white-space: -o-pre-wrap;    /* Opera 7 */
+        word-wrap: break-word;       /* Internet Explorer 5.5+ */
+      }
+      .toaster--message {
+        max-width: 30em;
+        line-height: 1.5em;
+      }
+      .toaster--message--label {
+        font-style: italic;
+      }
+    </style>
 
     <!-- Header -->
     <px-demo-header
@@ -77,6 +114,18 @@
               </px-data-table>
             </div>
         </template>
+        <div id="toaster" hidden="{{_toast.isHidden}}">
+          <div class="toaster--title">{{_toast.title}}</div>
+          <pre class="toaster--detail">evt.type: {{_toast.event}}</pre>
+          <pre class="toaster--detail">evt.detail: {{_toast.detail}}</pre>
+          <div class="toaster--message">
+            <span class="toaster--message--label">To update table: </span>
+            <span>{{_toast.message}}</span>
+          </div>
+          <div class="toaster--action-container">
+              <button class="btn" on-tap="_hideToast">Close</button>
+          </div>
+        </div>
       </px-demo-component>
       <!-- END Component ------------------------------------------------------>
 
@@ -171,6 +220,16 @@
       totalEntries : {
         type: Number,
         value: 100
+      },
+
+      _toast: {
+        type: Object,
+        value: {
+          detail: '',
+          isHidden: true,
+          message: '',
+          title: ''
+        }
       }
     },
 
@@ -267,25 +326,59 @@
       this.dataForDisplay = dataFullSet.slice(0,10);
 
       if (this.dataForDisplay.length > this.pageSize) {
-        alert('The number of items passed to the grid exceeds the number of rows expected. The controller of the data (external to the px-data-table) must pass in rational properties. e.g. If row count is set to 10, then it should send 10 items unless there are less than 10 in the entire data set.');
+        this.set('_toast', {
+          isHidden: false,
+          message: 'The number of items passed to the grid exceeds the number of rows expected. The controller of the data (external to the px-data-table) must pass in rational properties. e.g. If row count is set to 10, then it should send 10 items unless there are less than 10 in the entire data set.',
+          title: 'Edge Case Detected'
+        });
       }
 
     },
 
+    _hideToast: function () {
+      this.set('_toast', Object.assign({}, this._toast, {
+        isHidden: true
+      }));
+    },
+
     pageChangeHandler : function(evt){
-      alert('Container element trapped px-data-table event `px-page-change-intent`. Make a request to service for new data using the event detail captured here. On response from service, update the following properties passed into px-data-table: tableData, totalEntries, pageSize, firstItemIndex. Evt.detail: '+evt.detail+'.');
+      this.set('_toast', {
+        detail: evt.detail,
+        event: 'px-page-change-intent',
+        isHidden: false,
+        message: 'Make a request to service for new data using the event detail captured here. On response from service, update the following properties passed into px-data-table: tableData, totalEntries, pageSize, firstItemIndex.',
+        title: 'Page Change Event Detected'
+      });
     },
 
     pageSizeChangeHandler: function(evt){
-      alert('Container element trapped px-data-table event `px-page-size-change-intent`. Make a request to service for new data using the event detail captured here. On response from service, update the following properties passed into px-data-table: tableData, totalEntries, pageSize, firstItemIndex. Evt.detail: '+evt.detail+'.');
+      this.set('_toast', {
+        detail: evt.detail,
+        event: 'px-page-size-change-intent',
+        isHidden: false,
+        message: 'Make a request to service for new data using the event detail captured here. On response from service, update the following properties passed into px-data-table: tableData, totalEntries, pageSize, firstItemIndex.',
+        title: 'Page Size Change Detected'
+      });
     },
 
     pageFilterChangeHandler: function(evt){
-      alert('Container element trapped px-data-table event `px-filter-change-intent`. Make a request to service for new data using the event detail captured here. On response from service, update the following properties passed into px-data-table: tableData, totalEntries, pageSize, firstItemIndex. Evt.detail: '+evt.detail+'.');
+      this.set('_toast', {
+        detail: evt.detail,
+        event: 'px-filter-change-intent',
+        isHidden: false,
+        message: 'Make a request to service for new data using the event detail captured here. On response from service, update the following properties passed into px-data-table: tableData, totalEntries, pageSize, firstItemIndex.',
+        title: 'Page Filter Change Detected'
+      });
     },
 
     pageSortChangeHandler: function(evt){
-      alert('Container element trapped px-data-table event `px-sort-change-intent`. Make a request to service for new data using the event detail captured here. On response from service, update the following properties passed into px-data-table: tableData, totalEntries, pageSize, firstItemIndex. Evt.detail: '+evt.detail+'.');
+      this.set('_toast', {
+        detail: evt.detail,
+        event: 'px-sort-change-intent',
+        isHidden: false,
+        message: 'Make a request to service for new data using the event detail captured here. On response from service, update the following properties passed into px-data-table: tableData, totalEntries, pageSize, firstItemIndex.',
+        title: 'Page Filter Change Detected'
+      });
     }
 
   });

--- a/demo/px-data-table-demo.html
+++ b/demo/px-data-table-demo.html
@@ -134,12 +134,12 @@
               filterable: true,
               sortable: true,
               selectable: false,
-              singleSelect: true,
-              showColumnChooser: true,
+              singleSelect: false,
+              showColumnChooser: false,
               tableColumns: false,
               tableRows: false,
               hidePaginationControl: false,
-              includeAllColumns: false,
+              includeAllColumns: true,
               dataRemote: true },
           ]
         }

--- a/docs/server-side-data.md
+++ b/docs/server-side-data.md
@@ -2,13 +2,15 @@
 
 ## Advanced Example
 
+In the following example `serverResponse` is an object that is updated upon the response of a server.
+
 ```html
+
     <px-data-table
-      selected-rows="{{mySelectedItems}}"
-      filterable
-      selectable
-      striped
-      table-data="{{data}}"
+      id="remoteDataTable"
+      total-entries="{{serverResponse.totalRecordsCount}}"
+      first-item-index="{{serverResponse.recordIndexOfSubset}}"
+      table-data="{{serverResponse.dataSubset}}"
       remote-data="true"
       >
       <px-data-table-column
@@ -17,71 +19,75 @@
         filter-function-name="myTableCustomFunctions.filterWholeWord"
         sort-function-name="myTableCustomFunctions.sortByEmailDomain">
       </px-data-table-column>
-      <px-data-table-column name="last" ...></px-data-table-column>
-      <px-data-table-column name="color" ...></px-data-table-column>
-      <px-data-table-column name="date" ...></px-data-table-column>
+      <px-data-table-column name="last"></px-data-table-column>
+      <px-data-table-column name="color"></px-data-table-column>
+      <px-data-table-column name="date"></px-data-table-column>
     </px-data-table>
 ```
 
 ## Usage
 
-For container element ContainerEl, create the following event listeners and request new data based on the user-intended change. Upon receiving updated data, update the variable bound to the `table-data` attribute.
+For container element `ContainerEl`, create the following event listeners and request new data based on the user-intended change. Upon receiving updated data, update the variables bound to the `table-data`, `total-entries`, and `first-item-index` attributes.
 
 ### Events
 
+For full descriptions, run `gulp serve` and check out the [demo page](../demo/index.html).
+
 - `px-data-table-init`
-  - Fired when the data table initializes.
-  - Sends out initialization information (such as suggested page size based on available space)
-  - Only fired if dataRemote==true
-  - Information is stored in `evt.detail`:
-    ```javascript
-        document.getElementById("mytable").addEventListener("px-data-table-init", function(e) {
-          var data = e.detail;
-          console.log("Intended page: ", data);
-        });
-        // ==> {pageSize:10}
-    ```
 - `px-page-change-intent`
-  - Fired when the user interaction indicates an intention to change the page
-  - Only fired if dataRemote==true
-  - Information is stored in `evt.detail`:
-    ```javascript
-    document.getElementById("mytable").addEventListener("px-page-change-intent", function(e) {
-      var data = e.detail;
-      console.log("Intended page: ", data);
-    });
-    ```
 - `px-page-size-change-intent`
-  - Fired when the user interaction indicates an intention to change the page size
-  - Only fired if dataRemote==true
-  - Information is stored in `evt.detail`:
-    ```javascript
-    document.getElementById("mytable").addEventListener("px-page-size-change-intent", function(e) {
-      var data = e.detail;
-      console.log("Intended page size: ", data);
-    });
-    ```
 - `px-filter-change-intent`
-  - Fired when the user interaction indicates an intention to change the filter
-  - Captures filter data for all filtered columns
-  - Only fired if dataRemote==true
-  - Information is stored in `evt.detail`:
-    ```javascript
-    document.getElementById("mytable").addEventListener("px-filter-change-intent", function(e) {
-      var data = e.detail;
-      console.log("Intended filters: ", JSON.parse(data));
-    });
-    // ==> [{name:'columnA',userEntry:'asdf'},{name:'columnB',userEntry:'qwert'}]
-    ```
-- `px-sort-change-intent`
-  - Fired when the user interaction indicates an intention to change the sort
-  - Captures sort data for all sorted columns (currently only single sort allowed through UI)
-  - Only fired if dataRemote==true
-  - Information is stored in `evt.detail`:
-    ```javascript
-    document.getElementById("mytable").addEventListener("px-sort-change-intent", function(e) {
-      var data = e.detail;
-      console.log("Intended sort: ", JSON.parse(data));
-    });
-    // ==> [{name:'columnA',direction:'ascending'}] or [{name:'columnB',direction:'descending'}]
-    ```
+- `px-sort-change-intent`s
+
+
+## Example Usage
+
+### Markup
+
+```html
+  <div id="dataTableController">
+    <px-data-table
+      id="remoteDataTable"
+      total-entries="{{remoteData.totalRecordsCount}}"
+      first-item-index="{{remoteData.recordIndexOfSubset}}"
+      table-data="{{remoteData.dataSubset}}"
+      remote-data="true"
+      >
+      <px-data-table-column name="last"></px-data-table-column>
+    </px-data-table>
+  </div>
+```
+
+### Data Binding
+
+```javascript
+  var rdt = document.getElementById('remoteDataTable');
+
+  rdt.remoteData = {
+    totalRecordsCount: 0,
+    recordIndexOfSubset: 0,
+    dataSubset: []
+  };
+
+  rdt.addEventListener('px-page-change-intent', (evt) => {
+    composeFetchRequest({page: evt.detail});
+  });
+
+  function composeFetchRequest(options) {
+    fetchNewData('/someUrl', objToUrlParams(options));
+  }
+
+  function handleNewDataReceived (serverResponse) {
+    rdt.remoteData = {
+      totalRecordsCount: serverResponse.totalRecordsCount,
+      recordIndexOfSubset: serverResponse.recordIndexOfSubset,
+      dataSubset: serverResponse.dataSubset
+    };
+  }
+
+  function objToUrlParams (params) {
+    return Object.keys(params).map(function(k) {
+        return encodeURIComponent(k) + '=' + encodeURIComponent(a[k])
+    }).join('&');
+  }
+```

--- a/px-data-table.html
+++ b/px-data-table.html
@@ -12,7 +12,26 @@
 Element that defines a data table, optionally using a sub-element for advanced column settings.
 Use the dropdown at the top of this screen to see documentation on the `px-data-table-column` and `px-data-table-highlight` sub-components.
 
-### Usage
+### Client-Side VS Server-Side Data Paradigms
+
+There are two main paradigms for the source of data in a table.
+
+In a *Client-Side* model, the browser makes one request for the _complete set_ of data.
+This means that sorting, filtering, and pagination all happen in memory on the client.
+While this produces snappy tables with reasonably sized data sets, it can lead to a sluggish UI
+for larger data sets. This works great with data sets that don't change frequently,
+since the full payload would have to be resent for every update.
+
+In a *Server-Side* model, the browser makes a request for a _subset_ of data for a particular page.
+Sorting, filtering, and pagination requests will have to be made to a service for a new _subset_ of data
+that matches the user's intended criteria. This prevents the browser from being overwhelmed with excessively
+large data sets by only exposing one page's worth of data at a time. This is ideal for larger data sets or
+where it is preferable to make multiple small requests instead of fewer larger requests. Due to the increased
+frequency of requests, the UI is more likely to display data in sync with the server.
+
+### Client-Side Data Usage
+
+See the `README.md` and `docs` files in the repo for more details and advanced examples.
 
 Minimum:
 
@@ -26,6 +45,44 @@ Advanced:
       <px-data-table-column name="last" ...></px-data-table-column>
       <px-data-table-column name="color" ...></px-data-table-column>
       <px-data-table-column name="date" ...></px-data-table-column>
+    </px-data-table>
+
+### Server-Side Data Usage
+
+See the `README.md` and `docs` files in the repo for more details and advanced examples.
+
+For container element `ContainerEl`, create the following event listeners and request new data based on the user-intended change. Upon receiving updated data, update the variables bound to the `table-data`, `total-entries`, and `first-item-index` attributes.
+
+Minimum:
+
+    <px-data-table
+      total-entries="100"
+      first-item-index="11"
+      table-data="{{dataSubset}}"
+      remote-data="true"
+      >
+    </px-data-table>
+
+Advanced:
+
+In the following example `serverResponse` is an object that is updated upon the response of a server.
+
+    <px-data-table
+      id="remoteDataTable"
+      total-entries="{{serverResponse.totalRecordsCount}}"
+      first-item-index="{{serverResponse.recordIndexOfSubset}}"
+      table-data="{{serverResponse.dataSubset}}"
+      remote-data="true"
+      >
+      <px-data-table-column
+        name="first"
+        sortable
+        filter-function-name="myTableCustomFunctions.filterWholeWord"
+        sort-function-name="myTableCustomFunctions.sortByEmailDomain">
+      </px-data-table-column>
+      <px-data-table-column name="last"></px-data-table-column>
+      <px-data-table-column name="color"></px-data-table-column>
+      <px-data-table-column name="date"></px-data-table-column>
     </px-data-table>
 
 

--- a/test/px-data-table-test.js
+++ b/test/px-data-table-test.js
@@ -852,7 +852,7 @@ function runTests() {
       });
       test('Value of 5th data row 2nd column of first table should be "Rita Lopez"', function(done) {
         var tb = Polymer.dom(currentTableFixture.root).querySelector('aha-table'),
-            cell = Polymer.dom(tb.root).querySelectorAll('.aha-name-td')[5];
+            cell = Polymer.dom(tb.root).querySelectorAll('.aha-name-td')[4];
         flush(function () {
           assert.include(cell.textContent, 'Rita Lopez');
           done();
@@ -1277,9 +1277,9 @@ function runTests() {
             //verify order, 'index' should be last
             effChild = tb.getEffectiveChildren();
             headers = Polymer.dom(tb.root).querySelectorAll('.th');
-            assert.equal(effChild[effChild.length].name, 'index');
-            assert.equal(tb.meta[tb.meta.length].name, 'index');
-            assert.equal(headers[headers.length].textContent.trim(), 'Index');
+            assert.equal(effChild[effChild.length-1].name, 'index');
+            assert.equal(tb.meta[tb.meta.length-1].name, 'index');
+            assert.equal(headers[headers.length-1].textContent.trim(), 'Index');
 
             done();
           },100);
@@ -1520,7 +1520,7 @@ function runTests() {
         flush(function() {
           var selectionEls = Polymer.dom(filterInnerTable.root).querySelectorAll(selectionPath);
           assert.isTrue(filterRowEl.classList.contains('hidden'), 'tr--filter row should have hidden class');
-          assert.equal(selectionEls.length, 11);
+          assert.equal(selectionEls.length, 10);
           done();
         });
       });
@@ -1551,7 +1551,7 @@ function runTests() {
       suite('Unit tests for px-data-table-column dropdown mode', function() {
         test('Changing a dropdown cell updates the table data', function() {
           var tableFixture = currentTableFixture;
-          var dropdownCell = Polymer.dom(tableFixture.root).querySelector('aha-table').querySelectorAll('px-data-table-cell')[1];
+          var dropdownCell = Polymer.dom(tableFixture.root).querySelector('aha-table').querySelectorAll('px-data-table-cell')[0];
           var dropdown = Polymer.dom(dropdownCell.root).querySelector('px-dropdown');
           // Open dropdown
           dropdown.$.button.click();

--- a/test/px-data-table-test.js
+++ b/test/px-data-table-test.js
@@ -1277,9 +1277,9 @@ function runTests() {
             //verify order, 'index' should be last
             effChild = tb.getEffectiveChildren();
             headers = Polymer.dom(tb.root).querySelectorAll('.th');
-            assert.equal(effChild[effChild.length-1].name, 'index');
-            assert.equal(tb.meta[tb.meta.length-1].name, 'index');
-            assert.equal(headers[headers.length-1].textContent.trim(), 'Index');
+            assert.equal(effChild[effChild.length].name, 'index');
+            assert.equal(tb.meta[tb.meta.length].name, 'index');
+            assert.equal(headers[headers.length].textContent.trim(), 'Index');
 
             done();
           },100);


### PR DESCRIPTION
## Description

- ### Fixes
  - Hide/show filter/select row correctly
  - Fix single select and select all
  - Remove excess row
  - Corrects styling for Remote Data demo
  - Uses a toaster instead of `alert` for remote-data event info on demo page
- ### Documentation Updates
  - Adding Client-side VS Server-side clarification
  - Adding examples such that they show on the demo page