### PR TITLE
Added trigger call for page size change

### DIFF
--- a/px-pagination.html
+++ b/px-pagination.html
@@ -411,6 +411,7 @@ Element that provides pagination.
       if (!this.dataRemote) {
         this._goBackToFirstPage();
       } else {
+        this._triggerPageSizeChangeRequest(size)
         this.updateDisplay();
       }
     },


### PR DESCRIPTION
This is a proposed fix for issue [#179](https://github.com/PredixDev/px-data-table/issues/179)

The subscribed listener for _handledropdownchange does not execute on dropdown selected-changed event.  Adding an entrance for the _triggerPageSizeChangeRequest call from the _updatePageSize function (which is observed on pageSize change anyway) achieves the desired effect
